### PR TITLE
Add custom resource type names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+----------
+   * Add option to supply custom resource set name
+
 0.1.0 (2017-11-12)
 ------------------
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "fiunchinho/phpunit-randomizer": "2.0.*",
     "mockery/mockery": "0.9.*|^1.0@dev",
     "phpunit/phpunit": "^5.6",
-    "satooshi/php-coveralls": "dev-master"
+    "php-coveralls/php-coveralls": "dev-master"
   },
   "scripts": {
     "test": "phpunit",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,7 @@
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src/MetadataV3</directory>
             <directory suffix=".php">./src/StringTraits</directory>
+            <file>./src/BidirectionalMap.php</file>
             <file>./src/MetadataManager.php</file>
             <file>./src/xsdRestrictions.php</file>
         </whitelist>

--- a/src/BidirectionalMap.php
+++ b/src/BidirectionalMap.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace AlgoWeb\ODataMetadata;
+
+class BidirectionalMap
+{
+    private $keyToValue = [];
+    private $valueToKey = [];
+
+    public function reset()
+    {
+        $this->keyToValue = [];
+        $this->valueToKey = [];
+    }
+
+    public function hasKey($key)
+    {
+        return isset($this->keyToValue[$key]);
+    }
+
+    public function hasValue($value)
+    {
+        return isset($this->valueToKey[$value]);
+    }
+
+    public function getKey($value)
+    {
+        if ($this->hasKey($value)) {
+            return $this->valueToKey[$value];
+        }
+        return null;
+    }
+
+    public function getValue($key)
+    {
+        if ($this->hasKey($key)) {
+            return $this->keyToValue[$key];
+        }
+        return null;
+    }
+
+    public function getAllKeys()
+    {
+        if (0 !== $this->keyToValue) {
+            return array_keys($this->keyToValue);
+        }
+        return $this->keyToValue;
+    }
+
+    public function getAllValues()
+    {
+        if (0 !== $this->valueToKey) {
+            return array_keys($this->valueToKey);
+        }
+        return $this->valueToKey;
+    }
+
+    public function putAll($array)
+    {
+        foreach ($array as $key => $value) {
+            $this->put($key, $value);
+        }
+    }
+
+    public function put($key, $value)
+    {
+        if ($this->hasKey($key)) {
+            $this->removeKey($key);
+        }
+        if ($this->hasValue($key)) {
+            $this->removeValue($key);
+        }
+        $this->keyToValue[$key] = $value;
+        $this->valueToKey[$key] = $value;
+    }
+
+    public function removeKey($key)
+    {
+        if (!$this->hasKey($key)) {
+            return null;
+        }
+        unset($this->valueToKey[$this->keyToValue[$key]]);
+        $v = $this->keyToValue[$key];
+        unset($this->keyToValue[$key]);
+        return $v;
+    }
+
+    public function removeValue($value)
+    {
+        if (!$this->hasValue($value)) {
+            return null;
+        }
+        unset($this->keyToValue[$this->valueToKey[$value]]);
+        $k = $this->valueToKey[$value];
+        unset($this->valueToKey[$k]);
+        return $k;
+    }
+}

--- a/src/BidirectionalMap.php
+++ b/src/BidirectionalMap.php
@@ -25,7 +25,7 @@ class BidirectionalMap
 
     public function getKey($value)
     {
-        if ($this->hasKey($value)) {
+        if ($this->hasValue($value)) {
             return $this->valueToKey[$value];
         }
         return null;
@@ -41,7 +41,7 @@ class BidirectionalMap
 
     public function getAllKeys()
     {
-        if (0 !== $this->keyToValue) {
+        if (0 !== count($this->keyToValue)) {
             return array_keys($this->keyToValue);
         }
         return $this->keyToValue;
@@ -49,7 +49,7 @@ class BidirectionalMap
 
     public function getAllValues()
     {
-        if (0 !== $this->valueToKey) {
+        if (0 !== count($this->valueToKey)) {
             return array_keys($this->valueToKey);
         }
         return $this->valueToKey;
@@ -67,11 +67,11 @@ class BidirectionalMap
         if ($this->hasKey($key)) {
             $this->removeKey($key);
         }
-        if ($this->hasValue($key)) {
-            $this->removeValue($key);
+        if ($this->hasValue($value)) {
+            $this->removeValue($value);
         }
         $this->keyToValue[$key] = $value;
-        $this->valueToKey[$key] = $value;
+        $this->valueToKey[$value] = $key;
     }
 
     public function removeKey($key)

--- a/src/BidirectionalMap.php
+++ b/src/BidirectionalMap.php
@@ -13,16 +13,31 @@ class BidirectionalMap
         $this->valueToKey = [];
     }
 
+    /**
+     * Check if supplied key exists.
+     * @param $key
+     * @return bool
+     */
     public function hasKey($key)
     {
         return isset($this->keyToValue[$key]);
     }
 
+    /**
+     * Check if supplied key exists.
+     * @param $value
+     * @return bool
+     */
     public function hasValue($value)
     {
         return isset($this->valueToKey[$value]);
     }
 
+    /**
+     * Retrieve key matching supplied value.
+     * @param  mixed      $value
+     * @return mixed|null
+     */
     public function getKey($value)
     {
         if ($this->hasValue($value)) {
@@ -31,6 +46,11 @@ class BidirectionalMap
         return null;
     }
 
+    /**
+     * Retrieve value matching supplied key.
+     * @param  mixed      $key
+     * @return mixed|null
+     */
     public function getValue($key)
     {
         if ($this->hasKey($key)) {
@@ -74,25 +94,35 @@ class BidirectionalMap
         $this->valueToKey[$value] = $key;
     }
 
+    /**
+     * Remove supplied key from map and return matching value.
+     * @param  mixed      $key
+     * @return mixed|null
+     */
     public function removeKey($key)
     {
         if (!$this->hasKey($key)) {
             return null;
         }
         unset($this->valueToKey[$this->keyToValue[$key]]);
-        $v = $this->keyToValue[$key];
+        $value = $this->keyToValue[$key];
         unset($this->keyToValue[$key]);
-        return $v;
+        return $value;
     }
 
+    /**
+     * Remove supplied value from map and return matching key.
+     * @param  mixed      $value
+     * @return mixed|null
+     */
     public function removeValue($value)
     {
         if (!$this->hasValue($value)) {
             return null;
         }
         unset($this->keyToValue[$this->valueToKey[$value]]);
-        $k = $this->valueToKey[$value];
-        unset($this->valueToKey[$k]);
-        return $k;
+        $key = $this->valueToKey[$value];
+        unset($this->valueToKey[$value]);
+        return $key;
     }
 }

--- a/src/MetadataManager.php
+++ b/src/MetadataManager.php
@@ -67,6 +67,7 @@ class MetadataManager
      * @param  string               $accessType
      * @param  null                 $summary
      * @param  null                 $longDescription
+     * @param  null|mixed           $pluralName
      * @return IsOK[]
      */
     public function addEntityType(

--- a/src/MetadataManager.php
+++ b/src/MetadataManager.php
@@ -85,10 +85,12 @@ class MetadataManager
         $newEntity->setAbstract($isAbstract);
         $newEntity->setBaseType(null === $baseType ? null:$this->getNamespace() . $baseType->getName());
 
-        $setName = null !== $pluralName ? $pluralName : Str::plural($newEntity->getName());
+        if (null === $pluralName) {
+            $pluralName = Str::plural($newEntity->getName());
+        }
 
         $entitySet = new EntitySetAnonymousType();
-        $entitySet->setName($setName);
+        $entitySet->setName($pluralName);
         $namespace = $this->getNamespace();
         $entityTypeName = $namespace . $newEntity->getName();
         $entitySet->setEntityType($entityTypeName);

--- a/src/MetadataManager.php
+++ b/src/MetadataManager.php
@@ -456,7 +456,7 @@ class MetadataManager
         return $funcType;
     }
 
-    private function initSerialiser()
+    protected function initSerialiser()
     {
         $ymlDir = __DIR__ . DIRECTORY_SEPARATOR . 'MetadataV3' . DIRECTORY_SEPARATOR . 'JMSmetadata';
         $this->serializer =

--- a/src/MetadataManager.php
+++ b/src/MetadataManager.php
@@ -85,12 +85,10 @@ class MetadataManager
         $newEntity->setAbstract($isAbstract);
         $newEntity->setBaseType(null === $baseType ? null:$this->getNamespace() . $baseType->getName());
 
-        if (null === $pluralName) {
-            $pluralName = Str::plural($newEntity->getName());
-        }
+        $setName = null !== $pluralName ? $pluralName : Str::plural($newEntity->getName());
 
         $entitySet = new EntitySetAnonymousType();
-        $entitySet->setName($pluralName);
+        $entitySet->setName($setName);
         $namespace = $this->getNamespace();
         $entityTypeName = $namespace . $newEntity->getName();
         $entitySet->setEntityType($entityTypeName);

--- a/tests/BidirectionalMapTest.php
+++ b/tests/BidirectionalMapTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace AlgoWeb\ODataMetadata\Tests;
+
+use AlgoWeb\ODataMetadata\BidirectionalMap;
+
+class BidirectionalMapTest extends TestCase
+{
+    public function testRemoveKeyAndValueFromEmpty()
+    {
+        $foo = new BidirectionalMap();
+        $this->assertNull($foo->removeKey('key'));
+        $this->assertNull($foo->removeValue('value'));
+    }
+
+    public function testPut()
+    {
+        $foo = new BidirectionalMap();
+
+        $foo->put('foo', 'bar');
+        $this->assertEquals(1, count($foo->getAllKeys()));
+        $this->assertEquals(1, count($foo->getAllValues()));
+    }
+
+    public function testPutAllThenReset()
+    {
+        $foo = new BidirectionalMap();
+
+        $foo->putAll(['foo' => 'bar']);
+        $this->assertEquals(1, count($foo->getAllKeys()));
+        $this->assertEquals(1, count($foo->getAllValues()));
+        $foo->reset();
+        $this->assertEquals(0, count($foo->getAllKeys()));
+        $this->assertEquals(0, count($foo->getAllValues()));
+    }
+
+    public function testGetKeyAndValueSeparately()
+    {
+        $foo = new BidirectionalMap();
+
+        $foo->putAll(['foo' => 'bar']);
+        $this->assertEquals('bar', $foo->getValue('foo'));
+        $this->assertEquals('foo', $foo->getKey('bar'));
+        $foo->reset();
+        $this->assertEquals(null, $foo->getValue('foo'));
+        $this->assertEquals(null, $foo->getKey('bar'));
+    }
+
+    public function testPutWithOverlappingKeys()
+    {
+        $foo = new BidirectionalMap();
+
+        $foo->put('foo', 'bar');
+        $this->assertEquals('bar', $foo->getValue('foo'));
+        $this->assertEquals('foo', $foo->getKey('bar'));
+
+        $foo->put('foo', 'rebar');
+        $this->assertEquals(null, $foo->getKey('bar'));
+        $this->assertEquals('rebar', $foo->getValue('foo'));
+        $this->assertEquals('foo', $foo->getKey('rebar'));
+    }
+
+    public function testPutWithOverlappingValues()
+    {
+        $foo = new BidirectionalMap();
+
+        $foo->put('foo', 'bar');
+        $this->assertEquals('bar', $foo->getValue('foo'));
+        $this->assertEquals('foo', $foo->getKey('bar'));
+
+        $foo->put('nufoo', 'bar');
+        $this->assertEquals('nufoo', $foo->getKey('bar'));
+        $this->assertEquals(null, $foo->getValue('foo'));
+        $this->assertEquals('bar', $foo->getValue('nufoo'));
+    }
+}

--- a/tests/MetadataManagerDummy.php
+++ b/tests/MetadataManagerDummy.php
@@ -29,4 +29,9 @@ class MetadataManagerDummy extends MetadataManager
             $dependentConstraintProperty
         );
     }
+
+    public function getNamespace()
+    {
+        return parent::getNamespace();
+    }
 }

--- a/tests/MetadataManagerTest.php
+++ b/tests/MetadataManagerTest.php
@@ -18,6 +18,7 @@ use AlgoWeb\ODataMetadata\MetadataV3\edm\TNavigationPropertyType;
 use AlgoWeb\ODataMetadata\MetadataV3\edm\TTextType;
 use AlgoWeb\ODataMetadata\MetadataV3\edmx\Edmx;
 use AlgoWeb\ODataMetadata\MetadataV3\edmx\TDataServicesType;
+use JMS\Serializer\Serializer;
 use Mockery as m;
 
 class MetadataManagerTest extends \PHPUnit_Framework_TestCase
@@ -1132,6 +1133,37 @@ class MetadataManagerTest extends \PHPUnit_Framework_TestCase
         } catch (\InvalidArgumentException $e) {
             $actual = $e->getMessage();
         }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetEmptyNamespace()
+    {
+        $schema = m::mock(Schema::class);
+        $schema->shouldReceive('getNamespace')->andReturn(' ');
+
+        $edmx = m::mock(Edmx::class);
+        $edmx->shouldReceive('isOk')->andReturn(true);
+        $edmx->shouldReceive('getDataServiceType->getSchema')->andReturn([$schema]);
+
+        $foo = new MetadataManagerDummy('Data', 'DefaultContainer', $edmx);
+
+        $expected = '';
+        $actual = $foo->getNamespace();
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testInitSerialiserFromNull()
+    {
+        $cereal = m::mock(Serializer::class);
+        $cereal->shouldReceive('serialize')->andReturn('cereal')->once();
+
+        $foo = m::mock(MetadataManager::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $foo->shouldReceive('initSerialiser')->andReturn(null)->once();
+        $foo->shouldReceive('getSerialiser')->andReturn($cereal)->once();
+        $foo->shouldReceive('getEdmx')->andReturn(null)->once();
+
+        $expected = 'cereal';
+        $actual = $foo->getEdmxXML();
         $this->assertEquals($expected, $actual);
     }
 


### PR DESCRIPTION
Relax the baked-in assumption that resource type names must be strict English-language plural of entity type name.